### PR TITLE
List rmarkdown in Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ LazyData: true
 RoxygenNote: 7.1.1
 Encoding: UTF-8
 Imports: rrBLUP, methods, ggplot2, tidyr, stats
-Suggests: parallel, knitr
+Suggests: parallel, knitr, rmarkdown
 VignetteBuilder: knitr
 Collate: 
     'GWASpoly.data.R'


### PR DESCRIPTION
This should solve a problem that R-universe had building the vignette.  See https://github.com/r-universe/polyploids/runs/2707131178?check_suite_focus=true